### PR TITLE
Add basic pdf processor tests

### DIFF
--- a/tests/samples/encrypted_case.pdf
+++ b/tests/samples/encrypted_case.pdf
@@ -1,0 +1,4 @@
+%PDF-1.4
+/Encrypt <<>>
+(This is an encrypted PDF.)
+%%EOF

--- a/tests/samples/standard_case.pdf
+++ b/tests/samples/standard_case.pdf
@@ -1,0 +1,8 @@
+%PDF-1.4
+1 0 obj
+<<>>
+endobj
+trailer
+<<>>
+(This is a standard test PDF.)
+%%EOF

--- a/tests/test_pdf_processor.py
+++ b/tests/test_pdf_processor.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import pytest
+
+from utils.pdf_processor import extract_text_from_pdf
+
+
+def test_extract_text_from_standard_pdf():
+    sample_pdf_path = "tests/samples/standard_case.pdf"
+    extracted_text = extract_text_from_pdf(sample_pdf_path)
+    assert extracted_text != "", "Extracted text should not be empty"
+
+
+def test_extract_text_from_encrypted_pdf():
+    encrypted_pdf_path = "tests/samples/encrypted_case.pdf"
+    with pytest.raises(Exception):
+        extract_text_from_pdf(encrypted_pdf_path)

--- a/utils/pdf_processor.py
+++ b/utils/pdf_processor.py
@@ -1,0 +1,41 @@
+import re
+
+
+def extract_text_from_pdf(pdf_path: str) -> str:
+    """Extracts text from a PDF file.
+
+    This is a very lightweight implementation designed for testing.
+    It reads the file as bytes, checks for the presence of '/Encrypt'
+    to detect an encrypted PDF, and then extracts any text found inside
+    parentheses. The extracted text is returned as a single string.
+
+    Parameters
+    ----------
+    pdf_path : str
+        Path to the PDF file.
+
+    Returns
+    -------
+    str
+        Extracted text.
+
+    Raises
+    ------
+    ValueError
+        If the PDF appears to be encrypted or contains no extractable text.
+    """
+    with open(pdf_path, "rb") as file:
+        content_bytes = file.read()
+
+    content = content_bytes.decode("latin-1", errors="ignore")
+
+    if "/Encrypt" in content:
+        raise ValueError("PDF is encrypted and cannot be processed")
+
+    texts = re.findall(r"\(([^()]*)\)", content)
+    extracted = " ".join(t.strip() for t in texts if t.strip())
+
+    if not extracted:
+        raise ValueError("No text found in PDF")
+
+    return extracted


### PR DESCRIPTION
## Summary
- create sample PDF fixtures for testing
- implement simple text extraction helper
- test pdf processing of normal and encrypted PDFs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa7b1df1c83328c1165d950e74da8