### PR TITLE
Add initial bot skeleton

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,29 @@
+from telegram import Update
+from telegram.ext import ApplicationBuilder, MessageHandler, filters, CommandHandler
+
+try:
+    from config import TELEGRAM_BOT_TOKEN
+except ImportError:  # fallback to example configuration
+    from config_example import TELEGRAM_BOT_TOKEN
+from handlers.document_handler import handle_document
+from utils.logger import logger
+
+
+async def start(update: Update, _):
+    await update.message.reply_text("Добро пожаловать! Пришлите PDF для анализа.")
+
+
+def main() -> None:
+    if not TELEGRAM_BOT_TOKEN:
+        raise RuntimeError("TELEGRAM_BOT_TOKEN is not set")
+
+    app = ApplicationBuilder().token(TELEGRAM_BOT_TOKEN).build()
+    app.add_handler(CommandHandler("start", start))
+    app.add_handler(MessageHandler(filters.Document.PDF, handle_document))
+
+    logger.info("Bot started")
+    app.run_polling()
+
+
+if __name__ == "__main__":
+    main()

--- a/config_example.py
+++ b/config_example.py
@@ -1,0 +1,7 @@
+"""Example configuration for Telegram Case Bot."""
+
+TELEGRAM_BOT_TOKEN = ""
+OPENAI_API_KEY = ""
+ENCRYPTION_KEY = ""
+LOGGING_LEVEL = "INFO"
+REPORT_TEMPLATE_PATH = "data/templates/default.pdf"

--- a/exceptions/__init__.py
+++ b/exceptions/__init__.py
@@ -1,0 +1,4 @@
+from .openai_api_error import OpenAIAPIError
+from .pdf_processing_error import PDFProcessingError
+
+__all__ = ["OpenAIAPIError", "PDFProcessingError"]

--- a/exceptions/openai_api_error.py
+++ b/exceptions/openai_api_error.py
@@ -1,0 +1,2 @@
+class OpenAIAPIError(Exception):
+    """Raised when OpenAI API returns an error."""

--- a/exceptions/pdf_processing_error.py
+++ b/exceptions/pdf_processing_error.py
@@ -1,0 +1,2 @@
+class PDFProcessingError(Exception):
+    """Raised when a PDF cannot be processed."""

--- a/handlers/document_handler.py
+++ b/handlers/document_handler.py
@@ -1,0 +1,31 @@
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from utils.logger import logger
+from utils import pdf_processor
+from utils.openai_client import analyze_case_text
+from exceptions import OpenAIAPIError, PDFProcessingError
+
+
+async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    document = update.message.document
+    if not document:
+        return
+
+    file_path = await document.get_file()
+    local_path = file_path.download()
+    try:
+        text = pdf_processor.extract_text_from_pdf(local_path)
+    except Exception as exc:
+        logger.error("PDF processing failed: %s", exc)
+        await update.message.reply_text("Ошибка обработки PDF")
+        raise PDFProcessingError(str(exc)) from exc
+
+    try:
+        result = analyze_case_text(text)
+    except Exception as exc:
+        logger.error("OpenAI request failed: %s", exc)
+        await update.message.reply_text("Ошибка анализа файла")
+        raise OpenAIAPIError(str(exc)) from exc
+
+    await update.message.reply_text(result)

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -1,0 +1,10 @@
+class BotError(Exception):
+    """Base class for bot-related errors."""
+
+
+class PDFProcessingError(BotError):
+    pass
+
+
+class OpenAIAPIError(BotError):
+    pass

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,23 @@
+import logging
+import os
+from pathlib import Path
+
+try:  # use local config if present
+    from config import LOGGING_LEVEL
+except ImportError:  # fallback to example config
+    from config_example import LOGGING_LEVEL
+
+LOG_DIR = Path("logs")
+LOG_DIR.mkdir(exist_ok=True)
+LOG_FILE = LOG_DIR / "bot_errors.log"
+
+logging.basicConfig(
+    level=LOGGING_LEVEL,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[
+        logging.FileHandler(LOG_FILE),
+        logging.StreamHandler()
+    ]
+)
+
+logger = logging.getLogger("telegram_case_bot")

--- a/utils/openai_client.py
+++ b/utils/openai_client.py
@@ -1,0 +1,24 @@
+import openai
+
+try:
+    from config import OPENAI_API_KEY
+except ImportError:  # pragma: no cover - absent in repo
+    from config_example import OPENAI_API_KEY
+from utils.logger import logger
+
+openai.api_key = OPENAI_API_KEY
+
+
+def analyze_case_text(text: str) -> str:
+    """Send text to OpenAI and return the response text."""
+    try:
+        response = openai.Completion.create(
+            model="text-davinci-003",
+            prompt=text,
+            max_tokens=500,
+            temperature=0.7,
+        )
+        return response.choices[0].text.strip()
+    except Exception as exc:  # pragma: no cover - network failure
+        logger.error("OpenAI API call failed: %s", exc)
+        raise


### PR DESCRIPTION
## Summary
- implement example configuration
- add OpenAI client and logging setup
- create Telegram document handler and starter bot
- define basic custom exceptions
- include placeholder error classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa8bbe63083329a00413d5387dfa8